### PR TITLE
Add warning message if protocol missing or bad

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -97,6 +97,14 @@ function islandora_get_csv_query_solr($pid, $options) {
   $collection_fields_param = implode(',', $fields_used_in_collection);
  
   $solr_request = $protocol . $solr_endpoint . '/select?q=PID:*&wt=csv&rows=1000000&fq=' . $collection_filter . '&fl=' . $collection_fields_param;
+  if (strpos($solr_request, 'http://http://') !== false || strpos($solr_request, 'https://https://') !== false) {
+    drupal_set_message(t('Your Solr endpoint already contains the @protocol protocol.
+    Please configure islandora_get_csv and set Protocol to "None".'), 'error');
+  }
+  elseif (strpos($solr_request, 'http') !== 0) {
+    drupal_set_message(t('Your Solr endpoint lacks a protocol. Please configure islandora_get_csv 
+    and set Protocol to "http" or "https".'), 'error');
+  }
   $metadata_csv = @file_get_contents($solr_request);
 
   if ($options['islandora_get_csv_show_query']) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -97,7 +97,7 @@ function islandora_get_csv_query_solr($pid, $options) {
   $collection_fields_param = implode(',', $fields_used_in_collection);
  
   $solr_request = $protocol . $solr_endpoint . '/select?q=PID:*&wt=csv&rows=1000000&fq=' . $collection_filter . '&fl=' . $collection_fields_param;
-  if (strpos($solr_request, 'http://http://') !== false || strpos($solr_request, 'https://https://') !== false) {
+  if (strpos($solr_request, 'http://http://') !== false || strpos($solr_request, 'https://https://') !== false || strpos($solr_request, 'http://https://') !== false || strpos($solr_request, 'https://http://') !== false) {
     drupal_set_message(t('Your Solr endpoint already contains the %protocol protocol.
     Please configure islandora_get_csv and set Protocol to "None".', array('%protocol' => $protocol)), 'error');
   }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -98,8 +98,8 @@ function islandora_get_csv_query_solr($pid, $options) {
  
   $solr_request = $protocol . $solr_endpoint . '/select?q=PID:*&wt=csv&rows=1000000&fq=' . $collection_filter . '&fl=' . $collection_fields_param;
   if (strpos($solr_request, 'http://http://') !== false || strpos($solr_request, 'https://https://') !== false) {
-    drupal_set_message(t('Your Solr endpoint already contains the @protocol protocol.
-    Please configure islandora_get_csv and set Protocol to "None".'), 'error');
+    drupal_set_message(t('Your Solr endpoint already contains the %protocol protocol.
+    Please configure islandora_get_csv and set Protocol to "None".', array('%protocol' => $protocol)), 'error');
   }
   elseif (strpos($solr_request, 'http') !== 0) {
     drupal_set_message(t('Your Solr endpoint lacks a protocol. Please configure islandora_get_csv 


### PR DESCRIPTION
Addresses problems discussed in #7.

Introduces a check for Solr query problems when you generate the CSV, so that attempts to generate CSV with the module misconfigured do not just return nothing.

If the query built by islandora_get_csv contains `http://http://` or `https://https://`, it shows an error and tells you to fix it by setting Protocol to "none".

If the query does not contain `http`, it shows an error and tells you that you need to set a protocol on the config page.

To test:
- Configure islandora_get_csv with the wrong protocol setting
- Attempt to generate a CSV; observe you get no results
- Check out this branch, attempt a CSV again
- You should now see an appropriate warning
- Fix the Protocol configuration and try again; CSV should appear as expected

Notes:
- My Vagrant machine requires the http protocol be set, so that is what I tested for. This needs to be tested in an environment where the protocol is included in the endpoint, to make sure that the check for duplicated protocols also displays the warning appropriately.
- This does **not** add a check for whether selecting `https://` as your protocol is correct or not. If you have an `http` site with no certificate, selecting `https://` as your protocol will fail to generate a CSV without any notifications. Should there be a check for this? How would it work?