### PR TITLE
Add new include_descendants option to drush command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ You can also generate a CSV using Drush:
 
 `drush islandora-get-csv-get-csv --collection_pid=islandora:sp_basic_image_collection --output_file=/tmp/output.csv`
 
+To include objects in subcollections of this collection, use the `--include_descendants` option:
+
+`drush islandora-get-csv-get-csv --collection_pid=islandora:sp_basic_image_collection --include_descendants --output_file=/tmp/output.csv`
+
 ## Installation
 
 1. `git clone https://github.com/mjordan/islandora_get_csv.git`

--- a/islandora_get_csv.drush.inc
+++ b/islandora_get_csv.drush.inc
@@ -27,6 +27,9 @@ function islandora_get_csv_drush_command() {
           'description' => dt('Absolute or relative path to the output file.'),
           'required' => TRUE,
         ),
+        'include_descendents' => array(
+          'description' => dt('True or false - include child objects of child collections.'),
+        ),
       ),
       'examples' => array(
         'Get metadata for all items in the Islandora Basic Image collection' => 'drush islandora-get-csv-get-csv --collection_pid=islandora:sp_basic_image_collection --output_file=/tmp/output.csv',
@@ -68,6 +71,9 @@ function drush_islandora_get_csv_get_csv() {
   $options = array();
   foreach ($settings_variables as $variable) {
     $options[$variable] = variable_get($variable);
+  }
+  if(drush_get_option('include_descendents')) {
+    $options['islandora_get_csv_include_descendents'] = true;
   }
 
   $output_file_path = trim(drush_get_option('output_file'));

--- a/islandora_get_csv.drush.inc
+++ b/islandora_get_csv.drush.inc
@@ -27,7 +27,7 @@ function islandora_get_csv_drush_command() {
           'description' => dt('Absolute or relative path to the output file.'),
           'required' => TRUE,
         ),
-        'include_descendents' => array(
+        'include_descendants' => array(
           'description' => dt('True or false - include child objects of child collections.'),
         ),
       ),
@@ -72,7 +72,7 @@ function drush_islandora_get_csv_get_csv() {
   foreach ($settings_variables as $variable) {
     $options[$variable] = variable_get($variable);
   }
-  if(drush_get_option('include_descendents')) {
+  if(drush_get_option('include_descendants')) {
     $options['islandora_get_csv_include_descendents'] = true;
   }
 


### PR DESCRIPTION
Adds a new drush option `--include_descendants`, which gets all the child objects in a collection in the same way as the GUI. Addresses #17.

To test:

- Find a collection with subcollections
- Run the drush command normally and look at your CSV, which should only show the top-level children
- Add the option `--include_descendants` to the drush command and look at your new CSV. It should include the children's children as well.